### PR TITLE
fix(container): should render container type with space correctly

### DIFF
--- a/__test__/__snapshots__/index.spec.ts.snap
+++ b/__test__/__snapshots__/index.spec.ts.snap
@@ -1,30 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`compile > should render container content correctly 1`] = `
-"<div className=\\"\\">
-  <div className=\\"\\">TIP</div>
-  <div className=\\"\\">
+"<div>
+  <div>TIP</div>
+  <div>
     <p>First line <code>block</code></p>
     <p>Second line <code>block2</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">TIP</div>
-  <div className=\\"\\">
+<div>
+  <div>TIP</div>
+  <div>
     <ul>
       <li>List item 1 <code>block</code>。</li>
       <li>List item 2 <code>block2</code>。</li>
     </ul>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">TIP</div>
-  <div className=\\"\\">
+<div>
+  <div>TIP</div>
+  <div>
     <p>Some code:</p>
-    <div className=\\"\\">
-      <div className=\\"\\">
-        <button className=\\"\\"></button>
-        <pre className=\\"\\"><code className=\\"\\">console.log('hello world');
+    <div>
+      <div>
+        <button></button>
+        <pre><code>console.log('hello world');
 </code></pre>
       </div>
     </div>
@@ -252,15 +252,27 @@ export default MDXContent;
 `;
 
 exports[`compile > should render container title correctly 1`] = `
-"<div className=\\"\\">
-  <div className=\\"\\">Custom Title</div>
-  <div className=\\"\\">
+"<div>
+  <div>Custom Title</div>
+  <div>
     <p>This is a <code>block</code> of <code>Custom Title</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">Custom Title</div>
-  <div className=\\"\\">
+<div>
+  <div>Custom Title</div>
+  <div>
+    <p>This is a <code>block</code> of <code>Custom Title</code></p>
+  </div>
+</div>
+<div>
+  <div>Custom Title</div>
+  <div>
+    <p>This is a <code>block</code> of <code>Custom Title</code></p>
+  </div>
+</div>
+<div>
+  <div>Custom Title</div>
+  <div>
     <p>This is a <code>block</code> of <code>Custom Title</code></p>
   </div>
 </div>
@@ -336,7 +348,7 @@ function _createMdxContent(props) {
                         className: \\"modern-directive-content\\",
                         children: _jsxDEV(_components.p, {
                             children: [
-                                \\"This is a \\",
+                                \\"\\\\nThis is a \\",
                                 _jsxDEV(_components.code, {
                                     children: \\"block\\"
                                 }, undefined, false, {
@@ -350,6 +362,90 @@ function _createMdxContent(props) {
                                 }, undefined, false, {
                                     fileName: \\"xxx.mdx\\",
                                     lineNumber: 6,
+                                    columnNumber: 22
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive tip\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"Custom Title\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 10,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"Custom Title\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 10,
+                                    columnNumber: 22
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive tip\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"Custom Title\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 14,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"Custom Title\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 14,
                                     columnNumber: 22
                                 }, this),
                                 \\"\\\\n\\"
@@ -386,39 +482,39 @@ export default MDXContent;
 `;
 
 exports[`compile > should render container type correctly 1`] = `
-"<div className=\\"\\">
-  <div className=\\"\\">TIP</div>
-  <div className=\\"\\">
+"<div>
+  <div>TIP</div>
+  <div>
     <p>This is a <code>block</code> of type <code>tip</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">INFO</div>
-  <div className=\\"\\">
+<div>
+  <div>INFO</div>
+  <div>
     <p>This is a <code>block</code> of type <code>info</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">NOTE</div>
-  <div className=\\"\\">
+<div>
+  <div>NOTE</div>
+  <div>
     <p>This is a <code>block</code> of type <code>info</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">WARNING</div>
-  <div className=\\"\\">
+<div>
+  <div>WARNING</div>
+  <div>
     <p>This is a <code>block</code> of type <code>warning</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">DANGER</div>
-  <div className=\\"\\">
+<div>
+  <div>DANGER</div>
+  <div>
     <p>This is a <code>block</code> of type <code>danger</code></p>
   </div>
 </div>
-<div className=\\"\\">
-  <div className=\\"\\">CAUTION</div>
-  <div className=\\"\\">
+<div>
+  <div>CAUTION</div>
+  <div>
     <p>This is a <code>block</code> of type <code>danger</code></p>
   </div>
 </div>
@@ -676,6 +772,380 @@ function _createMdxContent(props) {
                                 }, undefined, false, {
                                     fileName: \\"xxx.mdx\\",
                                     lineNumber: 22,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this)
+        ]
+    }, undefined, true, {
+        fileName: \\"xxx.mdx\\",
+        lineNumber: 1,
+        columnNumber: 1
+    }, this);
+}
+function MDXContent(props = {}) {
+    const { wrapper: MDXLayout  } = Object.assign({}, _provideComponents(), props.components);
+    return MDXLayout ? _jsxDEV(MDXLayout, Object.assign({}, props, {
+        children: _jsxDEV(_createMdxContent, props, undefined, false, {
+            fileName: \\"xxx.mdx\\"
+        }, this)
+    }), undefined, false, {
+        fileName: \\"xxx.mdx\\"
+    }, this) : _createMdxContent(props);
+}
+export default MDXContent;
+"
+`;
+
+exports[`compile > should render container type with space correctly 1`] = `
+"<div>
+  <div>TIP</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>tip</code></p>
+  </div>
+</div>
+<div>
+  <div>TIP</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>tip</code></p>
+  </div>
+</div>
+<div>
+  <div>INFO</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>info</code></p>
+  </div>
+</div>
+<div>
+  <div>NOTE</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>info</code></p>
+  </div>
+</div>
+<div>
+  <div>WARNING</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>warning</code></p>
+  </div>
+</div>
+<div>
+  <div>DANGER</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>danger</code></p>
+  </div>
+</div>
+<div>
+  <div>CAUTION</div>
+  <div>
+    <p>This is a <code>block</code> of type <code>danger</code></p>
+  </div>
+</div>
+"
+`;
+
+exports[`compile > should render container type with space correctly 2`] = `
+"import { Fragment as _Fragment, jsxDEV as _jsxDEV } from \\"react/jsx-dev-runtime\\";
+import { useMDXComponents as _provideComponents } from \\"@mdx-js/react\\";
+export const frontmatter = {};
+export const title = '';
+export const toc = [];
+function _createMdxContent(props) {
+    const _components = Object.assign({
+        div: \\"div\\",
+        p: \\"p\\",
+        code: \\"code\\"
+    }, _provideComponents(), props.components);
+    return _jsxDEV(_Fragment, {
+        children: [
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive tip\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"TIP\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 2,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"tip\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 2,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive tip\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"TIP\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 6,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"tip\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 6,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive info\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"INFO\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 10,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"info\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 10,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive note\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"NOTE\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 14,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"info\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 14,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive warning\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"WARNING\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 18,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"warning\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 18,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive danger\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"DANGER\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 22,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"danger\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 22,
+                                    columnNumber: 27
+                                }, this),
+                                \\"\\\\n\\"
+                            ]
+                        }, undefined, true, {
+                            fileName: \\"xxx.mdx\\"
+                        }, this)
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this)
+                ]
+            }, undefined, true, {
+                fileName: \\"xxx.mdx\\"
+            }, this),
+            \\"\\\\n\\",
+            _jsxDEV(_components.div, {
+                className: \\"modern-directive caution\\",
+                children: [
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-title\\",
+                        children: \\"CAUTION\\"
+                    }, undefined, false, {
+                        fileName: \\"xxx.mdx\\"
+                    }, this),
+                    _jsxDEV(_components.div, {
+                        className: \\"modern-directive-content\\",
+                        children: _jsxDEV(_components.p, {
+                            children: [
+                                \\"This is a \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"block\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 26,
+                                    columnNumber: 11
+                                }, this),
+                                \\" of type \\",
+                                _jsxDEV(_components.code, {
+                                    children: \\"danger\\"
+                                }, undefined, false, {
+                                    fileName: \\"xxx.mdx\\",
+                                    lineNumber: 26,
                                     columnNumber: 27
                                 }, this),
                                 \\"\\\\n\\"

--- a/__test__/container-title.md
+++ b/__test__/container-title.md
@@ -2,6 +2,14 @@
 This is a `block` of `Custom Title`
 :::
 
+::: tip{title="Custom Title"}
+This is a `block` of `Custom Title`
+:::
+
 :::tip title="Custom Title"
+This is a `block` of `Custom Title`
+:::
+
+::: tip title="Custom Title"
 This is a `block` of `Custom Title`
 :::

--- a/__test__/container-type-with-space.md
+++ b/__test__/container-type-with-space.md
@@ -1,0 +1,27 @@
+::: tip
+This is a `block` of type `tip`
+:::
+
+:::   tip
+This is a `block` of type `tip`
+:::
+
+::: info
+This is a `block` of type `info`
+:::
+
+::: note
+This is a `block` of type `info`
+:::
+
+::: warning
+This is a `block` of type `warning`
+:::
+
+::: danger
+This is a `block` of type `danger`
+:::
+
+::: caution
+This is a `block` of type `danger`
+:::

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -14,7 +14,18 @@ describe("compile", () => {
       filepath: "xxx.mdx",
       development: true,
       root: "xxx",
-      defaultLang: "",
+    });
+
+    expect(formatHTML(html)).toMatchSnapshot();
+    expect(result).toMatchSnapshot();
+  });
+
+  test("should render container type with space correctly", async (t) => {
+    let { code: result, html } = await compile({
+      value: readFileSync(path.join(__dirname, "./container-type-with-space.md"), "utf8"),
+      filepath: "xxx.mdx",
+      development: true,
+      root: "xxx",
     });
 
     expect(formatHTML(html)).toMatchSnapshot();
@@ -30,7 +41,6 @@ describe("compile", () => {
       filepath: "xxx.mdx",
       development: true,
       root: "xxx",
-      defaultLang: "",
     });
 
     expect(formatHTML(html)).toMatchSnapshot();
@@ -43,7 +53,6 @@ describe("compile", () => {
       filepath: "xxx.mdx",
       development: true,
       root: "xxx",
-      defaultLang: "",
     });
 
     expect(formatHTML(html)).toMatchSnapshot();

--- a/crates/plugin_container/src/lib.rs
+++ b/crates/plugin_container/src/lib.rs
@@ -32,6 +32,7 @@ pub fn parse_container_meta(meta: &str) -> (String, String) {
     .skip(1)
     .next()
     .unwrap_or("")
+    .trim_start()
     .splitn(2, |c| c == ' ' || c == '{');
   // Parse the type and title individually. Such as :::tip title="title" -> ("tip", "title="title"}")
   let container_type = type_and_title.next().unwrap_or("").trim();


### PR DESCRIPTION
The container plugin should render container type with space correctly, so that the render result is consistent with the `@modern-js/remark-container`.

https://github.com/web-infra-dev/modern.js/blob/c911ca505fdab1725142f06527648dd5854abf7f/packages/toolkit/remark-container/tests/index.test.ts#L94