### PR TITLE
perf: use `mimalloc`

### DIFF
--- a/benches/index.mjs
+++ b/benches/index.mjs
@@ -3,12 +3,13 @@ import fs from "fs";
 import { compile as compileByMdxJs } from "@mdx-js/mdx";
 import Table from "cli-table";
 import path from "path";
+import { fileURLToPath } from "url";
 
 const table = new Table({
   head: ["Name", "Time Spend"],
 });
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const examplePath = path.resolve(__dirname, "./fixtures/example.md");
 const content = fs.readFileSync(examplePath, "utf-8");

--- a/crates/binding/Cargo.toml
+++ b/crates/binding/Cargo.toml
@@ -8,6 +8,12 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+mimalloc-rust = "0.2"
+
+[target.'cfg(all(target_os = "linux", not(all(target_env = "musl", target_arch = "aarch64"))))'.dependencies]
+mimalloc-rust = { version = "0.2", features = ["local-dynamic-tls"] }
+
 [dependencies]
 mdx_rs = { path = "../mdx_rs" }
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
@@ -21,3 +27,4 @@ napi-build = "2.0.1"
 
 [profile.release]
 lto = true
+codegen-units = 1

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(not(all(target_os = "linux", target_env = "musl", target_arch = "aarch64")))]
+#[global_allocator]
+static ALLOC: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+
 use mdx_plugin_toc::TocItem;
 use mdx_rs::{self, CompileResult};
 


### PR DESCRIPTION
Before: 
```sh
┌────────┬────────────┐
│ Name   │ Time Spend │
├────────┼────────────┤
│ mdx-js │ 4,656ms    │
├────────┼────────────┤
│ mdx-rs │ 2,838ms    │
└────────┴────────────┘
```

After:
```sh
┌────────┬────────────┐
│ Name   │ Time Spend │
├────────┼────────────┤
│ mdx-js │ 4,564ms    │
├────────┼────────────┤
│ mdx-rs │ 1,887ms    │
└────────┴────────────┘
```